### PR TITLE
 [Feat] #54 - 프로필 수정 api에 프로필 사진 처리 추가

### DIFF
--- a/Cookiee/Cookiee/Presentation/MyPage/MyPageView.swift
+++ b/Cookiee/Cookiee/Presentation/MyPage/MyPageView.swift
@@ -17,17 +17,41 @@ struct MyPageView: View {
         VStack (alignment: .leading) {
             VStack {
                 HStack {
-                    if let imageURL = profileViewModel.profile.profileImage {
-                        AsyncImage(url: URL(string: imageURL)) { result in
-                            result.image?
-                                .resizable()
-                                .clipShape(Circle())
-                                .frame(width: 129, height: 129)
+                    VStack {
+                        if let imageURL = profileViewModel.profile.profileImage {
+                            AsyncImage(url: URL(string: imageURL)) { phase in
+                                switch phase {
+                                case .empty:
+                                    Circle()
+                                        .fill(Color.Gray01)
+                                        .frame(width: 60, height: 60)
+                                        .overlay(ProgressView())
+                                case .success(let image):
+                                    image
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 60, height: 60)
+                                        .clipShape(Circle())
+                                    
+                                case .failure(_):
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .fill(Color.white)
+                                        .overlay(
+                                            Image(systemName: "photo")
+                                                .resizable()
+                                                .frame(width: 60, height: 60)
+                                                .aspectRatio(contentMode: .fit)
+                                                .foregroundStyle(Color.gray)
+                                        )
+                                @unknown default:
+                                    EmptyView()
+                                }
+                            }
+                        } else {
+                            Circle()
+                                .foregroundColor(Color.Gray01)
+                                .frame(width: 60, height: 60)
                         }
-                    } else {
-                        Circle()
-                            .foregroundColor(Color.Gray01)
-                            .frame(width: 70, height: 70)
                     }
                     
                     VStack(alignment: .leading) {
@@ -40,7 +64,7 @@ struct MyPageView: View {
                             .foregroundColor(Color.Brown02)
                     }
                     .frame(height: 50)
-                    .padding()
+                    .padding(.horizontal)
                     Spacer()
                     NavigationLink(
                         destination: ProfileEditView(),
@@ -52,7 +76,8 @@ struct MyPageView: View {
                         }
                     )
                 }
-                .padding()
+                .frame(height: 100)
+                .padding(.horizontal)
                 .background(Color.Gray00)
                 .cornerRadius(10)
             }

--- a/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
+++ b/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
@@ -40,49 +40,51 @@ struct ProfileEditView: View {
     var body: some View {
         VStack {
             HStack {
-                if let imageURL = profileViewModel.profile.profileImage {
-                    AsyncImage(url: URL(string: imageURL)) { phase in
-                        switch phase {
-                        case .empty:
-                            Circle()
-                                .fill(Color.Gray01)
-                                .frame(width: 129, height: 129)
-                                .overlay(ProgressView())
-                        case .success(let image):
-                            image
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 129, height: 129)
-                                .clipShape(Circle())
-                            
-                        case .failure(_):
-                            RoundedRectangle(cornerRadius: 2)
-                                .fill(Color.white)
-                                .overlay(
-                                    Image(systemName: "photo")
-                                        .resizable()
-                                        .frame(width: 129, height: 129)
-                                        .aspectRatio(contentMode: .fit)
-                                        .foregroundStyle(Color.gray)
-                                )
-                        @unknown default:
-                            EmptyView()
-                        }
-                    }
-                } else {
-                    Circle()
-                        .foregroundColor(Color.Gray01)
-                        .frame(width: 129, height: 129)
-                        .overlay(
-                            Button(action: {
-                                showImagePicker.toggle()
-                            }, label: {
-                                Image("Photo")
+                Button(action: {
+                    showImagePicker.toggle()
+                }, label: {
+                    if let imageURL = profileViewModel.profile.profileImage {
+                        AsyncImage(url: URL(string: imageURL)) { phase in
+                            switch phase {
+                            case .empty:
+                                Circle()
+                                    .fill(Color.Gray01)
+                                    .frame(width: 129, height: 129)
+                                    .overlay(ProgressView())
+                            case .success(let image):
+                                image
                                     .resizable()
-                                    .frame(width: 30, height: 30)
-                            })
-                        )
-                }
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 129, height: 129)
+                                    .clipShape(Circle())
+                                
+                            case .failure(_):
+                                RoundedRectangle(cornerRadius: 2)
+                                    .fill(Color.white)
+                                    .overlay(
+                                        Image(systemName: "photo")
+                                            .resizable()
+                                            .frame(width: 129, height: 129)
+                                            .aspectRatio(contentMode: .fit)
+                                            .foregroundStyle(Color.gray)
+                                    )
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
+                    } else {
+                        Circle()
+                            .foregroundColor(Color.Gray01)
+                            .frame(width: 129, height: 129)
+                            .overlay(
+                                VStack {
+                                    Image("Photo")
+                                        .resizable()
+                                        .frame(width: 30, height: 30)
+                                }
+                            )
+                    }
+                })
             }
             .sheet(isPresented: $showImagePicker, onDismiss: {
                 loadImage()

--- a/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
+++ b/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
@@ -181,6 +181,7 @@ struct ProfileEditView: View {
         }
         .onChange(of: profileViewModel.newSelectedImage) {
             newImage = profileViewModel.newSelectedImage
+            submitButtonColor = .Brown01
         }
     }
 }

--- a/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
+++ b/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
@@ -41,11 +41,33 @@ struct ProfileEditView: View {
         VStack {
             HStack {
                 if let imageURL = profileViewModel.profile.profileImage {
-                    AsyncImage(url: URL(string: imageURL)) { result in
-                        result.image?
-                            .resizable()
-                            .clipShape(Circle())
-                            .frame(width: 129, height: 129)
+                    AsyncImage(url: URL(string: imageURL)) { phase in
+                        switch phase {
+                        case .empty:
+                            Circle()
+                                .fill(Color.Gray01)
+                                .frame(width: 129, height: 129)
+                                .overlay(ProgressView())
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 129, height: 129)
+                                .clipShape(Circle())
+                            
+                        case .failure(_):
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(Color.white)
+                                .overlay(
+                                    Image(systemName: "photo")
+                                        .resizable()
+                                        .frame(width: 129, height: 129)
+                                        .aspectRatio(contentMode: .fit)
+                                        .foregroundStyle(Color.gray)
+                                )
+                        @unknown default:
+                            EmptyView()
+                        }
                     }
                 } else {
                     Circle()

--- a/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
+++ b/Cookiee/Cookiee/Presentation/MyPage/Profile/View/ProfileEditView.swift
@@ -27,12 +27,12 @@ struct ProfileEditView: View {
     
     @State var showImagePicker = false
     @State var selectedUIImage: UIImage?
-    @State var newImage: UIImage?
     @State var imageURL: String?
+    @State var newImage: UIImage?
 
     func loadImage() {
         guard let selectedImage = selectedUIImage else { return }
-        newImage = selectedImage
+        profileViewModel.newSelectedImage = selectedImage
     }
     
     @State var submitButtonColor: Color = .Gray02
@@ -44,32 +44,41 @@ struct ProfileEditView: View {
                     showImagePicker.toggle()
                 }, label: {
                     if let imageURL = profileViewModel.profile.profileImage {
-                        AsyncImage(url: URL(string: imageURL)) { phase in
-                            switch phase {
-                            case .empty:
-                                Circle()
-                                    .fill(Color.Gray01)
-                                    .frame(width: 129, height: 129)
-                                    .overlay(ProgressView())
-                            case .success(let image):
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 129, height: 129)
-                                    .clipShape(Circle())
-                                
-                            case .failure(_):
-                                RoundedRectangle(cornerRadius: 2)
-                                    .fill(Color.white)
-                                    .overlay(
-                                        Image(systemName: "photo")
-                                            .resizable()
-                                            .frame(width: 129, height: 129)
-                                            .aspectRatio(contentMode: .fit)
-                                            .foregroundStyle(Color.gray)
-                                    )
-                            @unknown default:
-                                EmptyView()
+                        if (newImage != nil) {
+                            Image(uiImage: newImage!)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 129, height: 129)
+                                .clipShape(Circle())
+                            
+                        } else {
+                            AsyncImage(url: URL(string: imageURL)) { phase in
+                                switch phase {
+                                case .empty:
+                                    Circle()
+                                        .fill(Color.Gray01)
+                                        .frame(width: 129, height: 129)
+                                        .overlay(ProgressView())
+                                case .success(let image):
+                                    image
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 129, height: 129)
+                                        .clipShape(Circle())
+                                    
+                                case .failure(_):
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .fill(Color.white)
+                                        .overlay(
+                                            Image(systemName: "photo")
+                                                .resizable()
+                                                .frame(width: 129, height: 129)
+                                                .aspectRatio(contentMode: .fit)
+                                                .foregroundStyle(Color.gray)
+                                        )
+                                @unknown default:
+                                    EmptyView()
+                                }
                             }
                         }
                     } else {
@@ -153,7 +162,7 @@ struct ProfileEditView: View {
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: backButton)
         .navigationBarItems(trailing: Button(action: {
-            profileViewModel.updateUserProfile(nickname: nickname, selfDescription: introduction, newUIImage: newImage)
+            profileViewModel.updateUserProfile(nickname: nickname, selfDescription: introduction, newUIImage: profileViewModel.newSelectedImage)
         }, label: {
             Text("완료")
                 .font(.Body0_B)
@@ -169,6 +178,9 @@ struct ProfileEditView: View {
             if profileViewModel.isSuccess {
                 presentationMode.wrappedValue.dismiss()
             }
+        }
+        .onChange(of: profileViewModel.newSelectedImage) {
+            newImage = profileViewModel.newSelectedImage
         }
     }
 }

--- a/Cookiee/Cookiee/Presentation/MyPage/Profile/ViewModel/ProfileViewModel.swift
+++ b/Cookiee/Cookiee/Presentation/MyPage/Profile/ViewModel/ProfileViewModel.swift
@@ -17,6 +17,7 @@ struct UserProfileData {
 class ProfileViewModel: ObservableObject {
     @Published var isSuccess: Bool = false
     @Published var profile = UserProfileData(nickname: "", selfDescription: "", profileImage: nil)
+    @Published var newSelectedImage: UIImage?
     
     let service = ProfileService()
     


### PR DESCRIPTION
## Close Issue
closed #54 

## 작업 내용
- 프로필 수정 api에 프로필 사진 처리 추가
- 사진 띄울시 뷰 비율 꺠짐 수정

## 스크린샷
<img width="513" alt="image" src="https://github.com/user-attachments/assets/df65142d-f413-4853-97cb-2e6ccd3a13ae">
<img width="513" alt="image" src="https://github.com/user-attachments/assets/8913afc5-2f46-444a-a0fd-6fb5c854e87f">
