### PR TITLE
[Feat] #56 - 썸네일 삭제 api 연결

### DIFF
--- a/Cookiee/Cookiee/Network/Thumbnail/DTO/Response/ThumbnailListResponseDTO.swift
+++ b/Cookiee/Cookiee/Network/Thumbnail/DTO/Response/ThumbnailListResponseDTO.swift
@@ -28,3 +28,10 @@ struct ThumbnailResponseDTO: Codable {
     let message: String
     let result: ThumbnailResultData
 }
+
+struct ThumbnailDeleteResponseDTO: Codable {
+    let isSuccess: Bool
+    let statusCode: Int
+    let message: String
+    let result: String?
+}

--- a/Cookiee/Cookiee/Network/Thumbnail/ThumbnailAPI.swift
+++ b/Cookiee/Cookiee/Network/Thumbnail/ThumbnailAPI.swift
@@ -12,6 +12,7 @@ enum ThumbnailAPI {
     case getThumbnailList(userId: String)
     case getTumbnailByDate(userId: String, year: Int, month: Int, day: Int)
     case postThumbnail(userId: String, requestBody: ThumbnailRequestDTO)
+    case deleteThumbnail(userId: String, thumbnailId: String)
 }
 
 extension ThumbnailAPI: BaseTargetType {
@@ -22,6 +23,8 @@ extension ThumbnailAPI: BaseTargetType {
         case .getTumbnailByDate:
             return .accessTokenHeaderForJson
         case .postThumbnail:
+            return .accessTokenHeaderForJson
+        case .deleteThumbnail:
             return .accessTokenHeaderForJson
         }
     }
@@ -34,6 +37,8 @@ extension ThumbnailAPI: BaseTargetType {
             return "/api/v2/thumbnails/date/\(userId)"
         case .postThumbnail(userId: let userId, _):
             return "/api/v2/thumbnails/\(userId)"
+        case .deleteThumbnail(userId: let userId, thumbnailId: let thumbnailId):
+            return "/api/v2/thumbnails/\(userId)/\(thumbnailId)"
         }
     }
     
@@ -45,6 +50,8 @@ extension ThumbnailAPI: BaseTargetType {
             return .get
         case .postThumbnail:
             return .post
+        case .deleteThumbnail:
+            return .delete
         }
     }
     
@@ -56,6 +63,9 @@ extension ThumbnailAPI: BaseTargetType {
             return .requestParameters(parameters: ["year": year, "month" : month, "day" : day],encoding: URLEncoding.queryString)
         case .postThumbnail(_, requestBody: let requestBody):
             return .uploadMultipart(multipartData(for: requestBody))
+        case .deleteThumbnail(_, _):
+            return .requestPlain
+
         }
     }
     

--- a/Cookiee/Cookiee/Network/Thumbnail/ThumbnailService.swift
+++ b/Cookiee/Cookiee/Network/Thumbnail/ThumbnailService.swift
@@ -75,4 +75,22 @@ class ThumbnailService {
             }
         }
     }
+    
+    func deleteThumbnail(thumbnailId: String, completion: @escaping (Result<ThumbnailDeleteResponseDTO, Error>) -> Void) {
+        provider.request(.deleteThumbnail(userId: userId, thumbnailId: thumbnailId)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    let response = try JSONDecoder().decode(ThumbnailDeleteResponseDTO.self, from: response.data)
+                    completion(.success(response))
+                } catch {
+                    completion(.failure(error))
+                    print("deleteThumbnail Decoding error:", error)
+                }
+            case .failure(let error):
+                completion(.failure(error))
+                print("deleteThumbnail error:", error)
+            }
+        }
+    }
 }

--- a/Cookiee/Cookiee/Presentation/Event/DateView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/DateView.swift
@@ -165,7 +165,7 @@ struct DateView: View {
                     Divider()
                     
                     Button(action: {
-                        
+                        thumbnailViewModel.removeThumbnail(thumbnailId: thumbnailId!.description)
                     }, label: {
                         HStack {
                             Image("TrashIconRed")

--- a/Cookiee/Cookiee/Presentation/Event/DateView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/DateView.swift
@@ -166,6 +166,7 @@ struct DateView: View {
                     
                     Button(action: {
                         thumbnailViewModel.removeThumbnail(thumbnailId: thumbnailId!.description)
+                        isThumbnailPutOrDeleteModalOpen = false
                     }, label: {
                         HStack {
                             Image("TrashIconRed")
@@ -214,7 +215,6 @@ struct DateView: View {
             }
         }
         .onChange(of: newImage) {
-            print("🔥 newImage 변경 감지")
             if newImage != nil {
                 let calendar = Calendar.current
                 

--- a/Cookiee/Cookiee/Presentation/Event/DateView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/DateView.swift
@@ -22,7 +22,7 @@ struct DateView: View {
     
     @StateObject private var viewModel = EventListViewModel()
     @ObservedObject private var thumbnailViewModel = ThumbnailViewModel()
-    @State private var isModalOpen: Bool = false
+    @State private var isEventDetailViewModalOpen: Bool = false
     
     var date: Date
 
@@ -109,7 +109,7 @@ struct DateView: View {
                 }
                 ScrollView {
                     EventCardGridView(eventList: viewModel.eventListData?.result ?? [], toggleModal: {
-                        isModalOpen.toggle()
+                        isEventDetailViewModalOpen.toggle()
                     })
                 }
                 HStack {
@@ -137,7 +137,7 @@ struct DateView: View {
 //                    .transition(.opacity.animation(.easeInOut(duration: 0.1)))
 //                : nil
 //            )
-            .sheet(isPresented: $isModalOpen) {
+            .sheet(isPresented: $isEventDetailViewModalOpen) {
                 EventDetailView(eventId: "58", date: date)
                     .presentationDetents([.fraction(0.99)])
                     .presentationDragIndicator(Visibility.visible)

--- a/Cookiee/Cookiee/Presentation/Event/DateView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/DateView.swift
@@ -23,6 +23,7 @@ struct DateView: View {
     @StateObject private var viewModel = EventListViewModel()
     @ObservedObject private var thumbnailViewModel = ThumbnailViewModel()
     @State private var isEventDetailViewModalOpen: Bool = false
+    @State private var isThumbnailPutOrDeleteModalOpen: Bool = false
     
     var date: Date
 
@@ -43,7 +44,7 @@ struct DateView: View {
                     HStack {
                         if !thumbnailViewModel.thumbnail.isEmpty {
                             Button(action: {
-                                print("썸네일 수정/삭제")
+                                isThumbnailPutOrDeleteModalOpen = true
                             }, label: {
                                 AsyncImage(url: URL(string: thumbnailViewModel.thumbnail)) { phase in
                                     switch phase {
@@ -142,12 +143,66 @@ struct DateView: View {
                     .presentationDetents([.fraction(0.99)])
                     .presentationDragIndicator(Visibility.visible)
             }
-            .sheet(isPresented: $showImagePicker, onDismiss: {
-                showImagePicker = false
-                loadImage()
-            }) {
-                ImagePicker(image: $selectedUIImage)
+            .sheet(isPresented: $isThumbnailPutOrDeleteModalOpen) {
+                VStack(spacing: 0) {
+                    Text("썸네일")
+                        .font(.Head1_B)
+                    
+                    Button(action: {
+                        
+                    }, label: {
+                        HStack {
+                            Image("EditIcon")
+                            Text("수정하기")
+                                .font(.Body0_M)
+                                .foregroundStyle(Color.black)
+                            Spacer()
+                        }
+                    })
+                    .frame(height: 44)
+                    .padding(.top, 10)
+                    
+                    Divider()
+                    
+                    Button(action: {
+                        
+                    }, label: {
+                        HStack {
+                            Image("TrashIconRed")
+                            Text("삭제하기")
+                                .font(.Body0_M)
+                                .foregroundStyle(Color.Error)
+                            Spacer()
+                        }
+                    })
+                    .frame(height: 44)
+
+                    Divider()
+                    
+                    Button(action: {
+                        isThumbnailPutOrDeleteModalOpen = false
+                    }, label: {
+                        HStack {
+                            Image("XmarkIcon")
+                            Text("취소")
+                                .font(.Body0_M)
+                                .foregroundStyle(Color.black)
+                            Spacer()
+                        }
+                    })
+                    .frame(height: 40)
+
+                }
+                .padding()
+                .presentationDetents([.fraction(0.27)])
+                .presentationDragIndicator(Visibility.visible)
             }
+//            .sheet(isPresented: $showImagePicker, onDismiss: {
+//                showImagePicker = false
+//                loadImage()
+//            }) {
+//                ImagePicker(image: $selectedUIImage)
+//            }
         }
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: backButton)
@@ -223,4 +278,8 @@ private func getFirstImageUrlAndCategory(from response: [String: Any]) -> [(imag
     }
 
     return results
+}
+
+#Preview {
+    DateView(date: Date.now)
 }

--- a/Cookiee/Cookiee/Presentation/Event/ViewModel/ThumbnailViewModel.swift
+++ b/Cookiee/Cookiee/Presentation/Event/ViewModel/ThumbnailViewModel.swift
@@ -55,4 +55,19 @@ class ThumbnailViewModel : ObservableObject {
             }
         }
     }
+    
+    func removeThumbnail(thumbnailId: String) {
+        service.deleteThumbnail(thumbnailId: thumbnailId) { result in
+            switch result {
+            case .success(let response):
+                DispatchQueue.main.async {
+                    self.thumbnail = ""
+                    print("✅ removeThumbnail 성공")
+               }
+            case .failure(let error):
+                print("❌ removeThumbnail 실패:", error)
+            }
+        }
+    }
+    
 }

--- a/Cookiee/Cookiee/Presentation/Event/ViewModel/ThumbnailViewModel.swift
+++ b/Cookiee/Cookiee/Presentation/Event/ViewModel/ThumbnailViewModel.swift
@@ -62,7 +62,7 @@ class ThumbnailViewModel : ObservableObject {
             case .success(let response):
                 DispatchQueue.main.async {
                     self.thumbnail = ""
-                    print("✅ removeThumbnail 성공")
+                    print("✅ removeThumbnail 성공", response)
                }
             case .failure(let error):
                 print("❌ removeThumbnail 실패:", error)


### PR DESCRIPTION
## Close Issue
closed #56 

## 작업 내용
- 썸네일 삭제 api 연결
- 수정/삭제 모달 뷰 구현

## 스크린샷
<img width="401" alt="image" src="https://github.com/user-attachments/assets/1edbaf50-5298-4da9-bfea-6bbd420714e4">
