### PR TITLE
[FEAT] #74 - 이벤트 생성 시 중간 선택 사진 삭제 기능 구현

### DIFF
--- a/Cookiee/Cookiee/Presentation/Event/View/EventAddView/ImageCarousel.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAddView/ImageCarousel.swift
@@ -16,6 +16,7 @@ struct ImageCarouselForPhotoPicker: View {
     
     @GestureState var offset: CGFloat = 0
     @State var currentIndex: Int = 0
+    @State var indexToDeleteInImageAttachment: Int = -1
     
     var body: some View {
         VStack {
@@ -24,61 +25,99 @@ struct ImageCarouselForPhotoPicker: View {
                 let adjustmentWidth = (trialingSpace / 2) - spacing
                 
                 HStack(spacing: spacing) {
-                    ForEach(viewModel.attachments) { imageAttachment in
-                        ImageAttachmentView(imageAttachment: imageAttachment)
-                        .frame(width: proxy.size.width - trialingSpace)
+                    ForEach(Array(viewModel.attachments.enumerated()), id: \.element.id) { index, imageAttachment in
+                        imageAttachmentCard(for: imageAttachment, at: index, width: width, proxy: proxy)
                     }
                     if (viewModel.selection.count < 5) {
-                        VStack {
-                            Button(action: {
-                                viewModel.isPhotoPickerPresented = true
-                            }, label: {
-                                VStack {
-                                    Image("PlusGray")
-                                        .resizable()
-                                        .frame(width: 35, height: 35)
-                                        .padding(10)
-                                }
-                                .frame(width: 270, height: 360)
-                            })
-                        }
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color.Gray04, lineWidth: 1)
-                        )
-                        .frame(width: proxy.size.width - trialingSpace)
-
+                        AddButtonView(proxy: proxy)
                     }
                 }
                 .padding(.horizontal, spacing)
                 .offset(x: (CGFloat(currentIndex) * -width) + (currentIndex != 0 ? adjustmentWidth : 0) + offset)
-                .gesture(
-                    DragGesture()
-                        .updating($offset, body: { value, out, _ in
-                            out = (value.translation.width / 1.5)
-                        })
-                        .onEnded { value in
-                            let offsetX = value.translation.width
-                            let progress = -offsetX / width
-                            let roundIndex = progress.rounded()
-                            
-                            if (viewModel.selection.count < 5) {
-                                currentIndex = max(min(currentIndex + Int(roundIndex), viewModel.attachments.count), 0)
-                            } else {
-                                currentIndex = max(min(currentIndex + Int(roundIndex), viewModel.attachments.count - 1), 0)
-                            }
-                            
-                        }
-                        .onChanged { value in
-                            let offsetX = value.translation.width
-                            let progress = -offsetX / width
-                            _ = progress.rounded()
-                        }
-                )
+                .gesture(dragGesture(width: width))
             }
             .animation(.easeInOut, value: offset == 0)
         }
         .frame(height: 360)
+    }
+    
+    private func overlayForDeletion(at index: Int, imageAttachment: ImagePickerForEventViewModel.ImageAttachment) -> some View {
+        VStack {
+            Button(action: {
+                viewModel.attachments.remove(at: index)
+                viewModel.selection.remove(at: index)
+                indexToDeleteInImageAttachment = -1
+            }, label: {
+                Image("TrashIconWhite")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 34, height: 34)
+            })
+        }
+        .frame(width: (imageAttachment.size?.width ?? 360) * 360 / (imageAttachment.size?.height ?? 360), height: 360)
+        .background(Color.black.opacity(0.5))
+        .onTapGesture {
+            if (indexToDeleteInImageAttachment == index) {
+                indexToDeleteInImageAttachment = -1
+            }
+        }
+    }
+    
+    private func imageAttachmentCard(for imageAttachment: ImagePickerForEventViewModel.ImageAttachment, at index: Int, width: CGFloat, proxy: GeometryProxy) -> some View {
+        ZStack {
+            ImageAttachmentView(imageAttachment: imageAttachment)
+                .onTapGesture {
+                    indexToDeleteInImageAttachment = index
+                }
+                .overlayIf(indexToDeleteInImageAttachment == index, overlayForDeletion(at: index, imageAttachment: imageAttachment))
+        }
+        .frame(width: proxy.size.width - trialingSpace)
+        .background(Color.white)
+    }
+    
+    private func dragGesture(width: CGFloat) -> some Gesture {
+        DragGesture()
+            .updating($offset) { value, out, _ in
+                out = (value.translation.width / 1.5)
+            }
+            .onEnded { value in
+                let offsetX = value.translation.width
+                let progress = -offsetX / width
+                let roundIndex = progress.rounded()
+
+                if (viewModel.selection.count < 5) {
+                    currentIndex = max(min(currentIndex + Int(roundIndex), viewModel.attachments.count), 0)
+                } else {
+                    currentIndex = max(min(currentIndex + Int(roundIndex), viewModel.attachments.count - 1), 0)
+                }
+            }
+            .onChanged { value in
+                let offsetX = value.translation.width
+                let progress = -offsetX / width
+                _ = progress.rounded()
+            }
+    }
+    
+    private func AddButtonView(proxy: GeometryProxy) -> some View {
+        VStack {
+            Button(action: {
+                viewModel.isPhotoPickerPresented = true
+            }, label: {
+                VStack {
+                    Image("PlusGray")
+                        .resizable()
+                        .frame(width: 35, height: 35)
+                        .padding(10)
+                }
+                .frame(width: 270, height: 360)
+            })
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.Gray04, lineWidth: 1)
+        )
+        .frame(width: proxy.size.width - trialingSpace)
+        .background(Color.white)
     }
 }
 


### PR DESCRIPTION
## Close Issue
closed #74 

## 작업 내용
- 이벤트 생성 시 중간에 선택한 사진 삭제할 수 있는 기능을 구현

## 스크린샷

https://github.com/user-attachments/assets/80f307e0-3a5a-435d-9a96-2987a25e4501

