### PR TITLE
[FIX] #76 - 이미지 캐러셀 중앙 정렬

### DIFF
--- a/Cookiee/Cookiee/Presentation/Event/View/EventAddView/ImageCarousel.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAddView/ImageCarousel.swift
@@ -11,7 +11,7 @@ import PhotosUI
 struct ImageCarouselForPhotoPicker: View {
     @ObservedObject var viewModel: ImagePickerForEventViewModel
 
-    var spacing: CGFloat = 10
+    var spacing: CGFloat = 15
     var trialingSpace: CGFloat = 30
     
     @GestureState var offset: CGFloat = 0

--- a/Cookiee/Cookiee/Presentation/Event/View/EventEditView/ImageCarouselForUIImage.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventEditView/ImageCarouselForUIImage.swift
@@ -11,7 +11,7 @@ struct ImageCarouselForUIImage: View {
     @StateObject var imagePickerForEventViewModel: ImagePickerForEventViewModel
     @StateObject var imageViewModelForPut: ImageViewModelForPut
 
-    var spacing: CGFloat = 10
+    var spacing: CGFloat = 15
     var trialingSpace: CGFloat = 30
     
     @GestureState var offset: CGFloat = 0

--- a/Cookiee/Cookiee/UIComponent/ImageCarouselView.swift
+++ b/Cookiee/Cookiee/UIComponent/ImageCarouselView.swift
@@ -22,45 +22,26 @@ struct ImageCarouselView: View {
         self.trialingSpace = trialingSpace
         self._index = index
     }
-    
     var body: some View {
-        VStack(alignment: .center) {
-            GeometryReader { proxy in
-                let width = proxy.size.width - (trialingSpace - spacing)
-                let adjustmentWidth = (trialingSpace / 2) - spacing
-                
-                HStack(alignment: .center, spacing: spacing) {
-                    ForEach(Array(imageUrls.enumerated()), id: \.offset) { offset, url in
-                        fetchImageByURL(url: url)
-                        .frame(width: proxy.size.width - trialingSpace)
+        VStack {
+            VStack {
+                GeometryReader { proxy in
+                    let width = proxy.size.width - (trialingSpace - spacing)
+                    let adjustmentWidth = (trialingSpace / 2) - spacing
+                    
+                    HStack(spacing: spacing) {
+                        ForEach(Array(imageUrls.enumerated()), id: \.offset) { offset, url in
+                            fetchImageByURL(url: url)
+                            .frame(width: proxy.size.width - trialingSpace)
+                        }
                     }
+                    .padding(.horizontal, spacing)
+                    .offset(x: (CGFloat(currentIndex) * -width) + (currentIndex != 0 ? adjustmentWidth : 0) + offset)
+                    .gesture(dragGesture(width: width))
                 }
-                .padding(.horizontal, spacing)
-                .offset(x: (CGFloat(currentIndex) * -width) + (currentIndex != 0 ? adjustmentWidth : 0) + offset)
-                .gesture(
-                    DragGesture()
-                        .updating($offset, body: { value, out, _ in
-                            out = (value.translation.width / 1.5)
-                        })
-                        .onEnded { value in
-                            let offsetX = value.translation.width
-                            let progress = -offsetX / width
-                            let roundIndex = progress.rounded()
-                            
-                            currentIndex = max(min(currentIndex + Int(roundIndex), imageUrls.count - 1), 0)
-                            
-                            index = currentIndex
-                        }
-                        .onChanged { value in
-                            let offsetX = value.translation.width
-                            let progress = -offsetX / width
-                            let roundIndex = progress.rounded()
-                            
-                            index = max(min(currentIndex + Int(roundIndex), imageUrls.count - 1), 0)
-                        }
-                )
+                .animation(.easeInOut, value: offset == 0)
             }
-            .animation(.easeInOut, value: offset == 0)
+            .frame(height: 360)
             
             HStack(spacing: 8) {
                 ForEach(0..<imageUrls.count, id: \.self) { i in
@@ -77,6 +58,29 @@ struct ImageCarouselView: View {
                 }
             }
         }
+    }
+    
+    private func dragGesture(width: CGFloat) -> some Gesture {
+        DragGesture()
+            .updating($offset, body: { value, out, _ in
+                out = (value.translation.width / 1.5)
+            })
+            .onEnded { value in
+                let offsetX = value.translation.width
+                let progress = -offsetX / width
+                let roundIndex = progress.rounded()
+                
+                currentIndex = max(min(currentIndex + Int(roundIndex), imageUrls.count - 1), 0)
+                
+                index = currentIndex
+            }
+            .onChanged { value in
+                let offsetX = value.translation.width
+                let progress = -offsetX / width
+                let roundIndex = progress.rounded()
+                
+                index = max(min(currentIndex + Int(roundIndex), imageUrls.count - 1), 0)
+            }
     }
 }
 

--- a/Cookiee/Cookiee/UIComponent/ImageCarouselView.swift
+++ b/Cookiee/Cookiee/UIComponent/ImageCarouselView.swift
@@ -16,7 +16,7 @@ struct ImageCarouselView: View {
     @GestureState var offset: CGFloat = 0
     @State var currentIndex: Int = 0
     
-    init(spacing: CGFloat = 10, trialingSpace: CGFloat = 30, index: Binding<Int>, imageUrls: [String]) {
+    init(spacing: CGFloat = 15, trialingSpace: CGFloat = 30, index: Binding<Int>, imageUrls: [String]) {
         self.imageUrls = imageUrls
         self.spacing = spacing
         self.trialingSpace = trialingSpace


### PR DESCRIPTION
## Close Issue
closed #76 

## 작업 내용
- 이벤트 이미지 캐러셀들 중앙정렬
- spacing이 trailingSpace의 절반이 되어야 함

## 스크린샷
<img width="370" alt="image" src="https://github.com/user-attachments/assets/ec867973-b276-4446-beb0-a8eac34dd26e">
