### PR TITLE
[FIX] #79 - asynchronous -> URLSession 변경

### DIFF
--- a/Cookiee/Cookiee/Presentation/Event/View/EventEditView/EventEditView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventEditView/EventEditView.swift
@@ -256,8 +256,15 @@ struct EventEditView: View {
             categorySelectViewModel.selectedCategory = eventViewModel.eventDetail!.categories
             
             for url in eventViewModel.eventDetail!.eventImageUrlList {
-                guard let image = urlToUIImage(url: url) else { continue }
-                imageViewModelForPut.uiImageList.append(image)
+                urlToUIImage(url: url) { image in
+                    if let image = image {
+                        DispatchQueue.main.async {
+                            imageViewModelForPut.uiImageList.append(image)
+                        }
+                    } else {
+                        print("Failed to load image")
+                    }
+                }
             }
         }
     }

--- a/Cookiee/Cookiee/Utils/urlToUIImage.swift
+++ b/Cookiee/Cookiee/Utils/urlToUIImage.swift
@@ -8,12 +8,27 @@
 import Foundation
 import UIKit
 
-func urlToUIImage(url: String) -> UIImage? {
-    guard let url = URL(string: url) else { return nil }
-    do {
-        let data = try Data(contentsOf: url)
-        return UIImage(data: data)
-    } catch {
-        return nil
+func urlToUIImage(url: String, completion: @escaping (UIImage?) -> Void) {
+    guard let url = URL(string: url) else {
+        completion(nil)
+        return
     }
+
+    URLSession.shared.dataTask(with: url) { data, response, error in
+        if let error = error {
+            print("Error fetching image: \(error.localizedDescription)")
+            completion(nil)
+            return
+        }
+
+        guard let data = data, let image = UIImage(data: data) else {
+            completion(nil)
+            return
+        }
+
+        // 결과를 메인 스레드에서 반환
+        DispatchQueue.main.async {
+            completion(image)
+        }
+    }.resume()
 }


### PR DESCRIPTION
## Close Issue
closed #79 

## 작업 내용
- 동기 오류 메시지 해결
- Synchronous URL loading of [이미지URL] should not occur on this application's main thread as it may lead to UI unresponsiveness. Please switch to an asynchronous networking API such as URLSession.
