### PR TITLE
[FEAT] #126 - refresh token 만료 후 재로그인

### DIFF
--- a/Cookiee/Cookiee/Network/Auth/Token/TokenInterceptor.swift
+++ b/Cookiee/Cookiee/Network/Auth/Token/TokenInterceptor.swift
@@ -46,6 +46,7 @@ final class TokenInterceptor: RequestInterceptor {
                 completion(.retry)
             case .failure(let error):
                 print("🔐 postRefreshToken Error: \(error)")
+                print("🔐 refresh 토큰 만료. 재로그인 필요")
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/Cookiee/Cookiee/Network/Auth/Token/TokenInterceptor.swift
+++ b/Cookiee/Cookiee/Network/Auth/Token/TokenInterceptor.swift
@@ -16,22 +16,36 @@ final class TokenInterceptor: RequestInterceptor {
     
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         print("retry 진입")
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
-        else {
+        
+        guard let response = request.task?.response as? HTTPURLResponse else {
             completion(.doNotRetryWithError(error))
-            print("retry : 401이 아님")
+            print("retry : response가 없음")
             return
         }
 
+        if response.statusCode == 401 {
+            print("retry : 401 오류 발생")
+            refreshAccessToken(request: request, completion: completion)
+        } else if response.statusCode == 500 {
+            print("retry : 500 서버 오류 발생, 토큰 만료 가능성 있음")
+            refreshAccessToken(request: request, completion: completion)
+        } else {
+            completion(.doNotRetryWithError(error))
+            print("retry : 401이나 500이 아님")
+        }
+    }
+
+    private func refreshAccessToken(request: Request, completion: @escaping (RetryResult) -> Void) {
         let tokenRefreshService = TokenRefreshService()
         tokenRefreshService.postRefreshToken() { result in
             switch result {
             case .success(let response):
-                print("@@@ postRefreshToken Response: \(response)")
+                print("🔐 postRefreshToken Response: \(response)")
+                print("🔐 Access Token 재설정")
                 saveToKeychain(key: "accessToken", data: response.result.accessToken)
                 completion(.retry)
             case .failure(let error):
-                print("@@@ postRefreshToken Error: \(error)")
+                print("🔐 postRefreshToken Error: \(error)")
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/Cookiee/Cookiee/Presentation/Account/SocialLogin/View/GoogleLoginInButton.swift
+++ b/Cookiee/Cookiee/Presentation/Account/SocialLogin/View/GoogleLoginInButton.swift
@@ -71,8 +71,14 @@ struct GoogleLoginInButton: View {
                     print("=====================================")
                     socialLoginViewModel.socialId = response.result.socialId
                     socialLoginViewModel.socialLoginType = "google"
-                    socialLoginViewModel.socialRefreshToken = response.result.refreshToken ?? ""
-                    socialLoginViewModel.socialAccessToken = response.result.accessToken ?? ""
+                    if response.result.refreshToken != nil {
+                        socialLoginViewModel.socialRefreshToken = response.result.refreshToken
+                        saveToKeychain(key: "refreshToken", data: response.result.refreshToken!)
+                    }
+                    if response.result.accessToken != nil {
+                        socialLoginViewModel.socialAccessToken = response.result.accessToken
+                        saveToKeychain(key: "accessToken", data: response.result.accessToken!)
+                    }
                     isNewMember = response.result.isNewMember
                     
                     continuation.resume(returning: true)

--- a/Cookiee/Cookiee/Presentation/ContentView.swift
+++ b/Cookiee/Cookiee/Presentation/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     
     @State var isLaunching: Bool = true
+    @State var tokenExpired: Bool = false
        
        var body: some View {
            if isLaunching {
@@ -19,17 +20,43 @@ struct ContentView: View {
                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                            withAnimation(.easeIn(duration: 0.2)) {
                                isLaunching = false
+                               checkTokenStatus()
                            }
                        }
                    }
            } else {
-               if loadFromKeychain(key: "accessToken") != nil  {
-                   TabBarView()
-               } else {
+               if tokenExpired {
                    SocialLoginView()
+               } else {
+                   TabBarView()
                }
            }
        }
+    
+    func checkTokenStatus() {
+        isRefrehTokenExpired { expired in
+            DispatchQueue.main.async {
+                tokenExpired = expired
+            }
+        }
+    }
+    
+    func isRefrehTokenExpired(completion: @escaping (Bool) -> Void) {
+        let tokenRefreshService = TokenRefreshService()
+        tokenRefreshService.postRefreshToken() { result in
+            switch result {
+            case .success(let response):
+                print("🔐 postRefreshToken Response: \(response)")
+                print("🔐 Access Token 재설정")
+                saveToKeychain(key: "accessToken", data: response.result.accessToken)
+                completion(false)
+            case .failure(let error):
+                print("🔐 postRefreshToken Error: \(error)")
+                print("🔐 refresh 토큰 만료. 재로그인 필요")
+                completion(true)
+            }
+        }
+    }
 }
 
 #Preview {


### PR DESCRIPTION
## Close Issue
closed #126 


## 작업 내용
-  refresh token 만료 후 재로그인
- 회원가입 시에만 저장했던 토큰들을 구글 로그인, 애플 로그인 둘 다 로그인 완료 후 토큰 저장하도록 추가

