### PR TITLE
[FIX] #133 - 지도 검색 바 네비게이션 영역으로 이동

### DIFF
--- a/Cookiee/Cookiee/Presentation/Event/View/EventMapView/EventMapLocationSearchBarUIView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventMapView/EventMapLocationSearchBarUIView.swift
@@ -28,12 +28,12 @@ struct EventMapLocationSearchBarUIView: UIViewRepresentable {
     }
 
     func makeUIView(context: UIViewRepresentableContext<EventMapLocationSearchBarUIView>) -> UISearchBar {
-        let searchBar = UISearchBar(frame: .zero)
+        let searchBar = UISearchBar()
         searchBar.delegate = context.coordinator
         searchBar.searchBarStyle = .minimal
         searchBar.barTintColor = UIColor(Color.Gray01)
         searchBar.placeholder = "장소를 검색하세요"
-        searchBar.searchTextField.leftView?.frame = CGRect(x: 0, y: 0, width: 100, height: 20)
+        searchBar.searchTextField.font = UIFont.Body0_R_UIFont
         
         return searchBar
     }

--- a/Cookiee/Cookiee/Presentation/Event/View/EventMapView/EventMapLocationSearchView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventMapView/EventMapLocationSearchView.swift
@@ -20,6 +20,7 @@ struct EventMapLocationSearchView: View {
                 Image("ChevronLeftIconBlack")
                     .aspectRatio(contentMode: .fit)
             }
+            .padding(.leading, 5)
         }
     }
 
@@ -33,10 +34,12 @@ struct EventMapLocationSearchView: View {
     var body: some View {
         VStack {
             VStack {
-                VStack {
+                HStack {
+                    backButton
                     EventMapLocationSearchBarUIView(text: $locationSearchService.searchQuery)
                 }
-                .padding([.bottom, .horizontal], 7)
+                .padding(.bottom, 7)
+                .padding(.horizontal, 5)
                 .background(Color.white)
             }
             .shadow(color: .black.opacity(0.1), radius: 5, x: 0, y: 2)
@@ -77,11 +80,7 @@ struct EventMapLocationSearchView: View {
             
             Spacer()
         }
-        .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
-        .toolbar {
-            toolbarItems
-        }
         
         .sheet(isPresented: $isPlaceSelected, onDismiss: {
             selectedLocation = nil
@@ -195,15 +194,6 @@ struct EventMapLocationSearchView: View {
                         longitude: region.longitude
                     ), distance: 500)
                 )
-            }
-        }
-    }
-
-    
-    private var toolbarItems: some ToolbarContent {
-        Group {
-            ToolbarItem(placement: .navigationBarLeading) {
-                backButton
             }
         }
     }

--- a/Cookiee/Cookiee/Resource/FontExtension.swift
+++ b/Cookiee/Cookiee/Resource/FontExtension.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 
 extension Font {
@@ -29,4 +30,17 @@ extension Font {
     static let Head0_B_22: Font = .custom("Pretendard-Bold", size: 22)
     static let Head0_B_24: Font = .custom("Pretendard-Bold", size: 24)
     static let Body3_R: Font = .custom("Pretendard-Regular", size: 10)
+}
+
+extension UIFont {
+    static func font(_ style: String, ofSize size: CGFloat) -> UIFont {
+        guard let customFont = UIFont(name: style, size: size) else {
+            return UIFont.systemFont(ofSize: size)
+        }
+        return customFont
+    }
+    
+    @nonobjc class var Body0_R_UIFont: UIFont {
+        return UIFont.font("Pretendard-Regular", ofSize: 16)
+    }
 }


### PR DESCRIPTION
## Close Issue
closed #133 

## 작업 내용
- 백 버튼과 검색 바 HStack으로 묶음
- 검색 바 폰트 설정

## 스크린샷
<img width="415" alt="image" src="https://github.com/user-attachments/assets/7cf6597b-4aca-4095-82ac-bcda278dde72" />
