### PR TITLE
[FIX] #157 - 이벤트 추가수정 내용 필드 3줄로 변경, 키보드 내리기

### DIFF
--- a/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventAddView/EventAddView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventAddView/EventAddView.swift
@@ -62,6 +62,10 @@ struct EventAddView: View {
                 .padding(.top, 10)
             submittingOverlay
         }
+        .onAppear() {
+            isFocused = false
+        }
+        
         .photosPicker(
             isPresented: $imagePickerForEventViewModel.isPhotoPickerPresented,
             selection: $imagePickerForEventViewModel.selection,

--- a/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventAddView/EventAddView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventAddView/EventAddView.swift
@@ -142,6 +142,7 @@ struct EventAddView: View {
                 content: $content,
                 people: $people,
                 place: $place,
+                isFocused: $isFocused,
                 categorySelectViewModel: categorySelectViewModel,
                 isCategorySelectButtonTapped: $isCategorySelectButtonTapped,
                 locationSearchService: locationSearchService

--- a/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventEditView/EventEditView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventEditView/EventEditView.swift
@@ -62,6 +62,7 @@ struct EventEditView: View {
             submittingOverlay
         }
         .onAppear() {
+            isFocused = false
             if !isInitialDataLoaded {
                 loadInitialData()
             }

--- a/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventEditView/EventEditView.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventEditView/EventEditView.swift
@@ -141,6 +141,7 @@ struct EventEditView: View {
                 content: $content,
                 people: $people,
                 place: $place,
+                isFocused: $isFocused,
                 categorySelectViewModel: categorySelectViewModel,
                 isCategorySelectButtonTapped: $isCategorySelectButtonTapped,
                 locationSearchService: locationSearchService

--- a/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventFormFields.swift
+++ b/Cookiee/Cookiee/Presentation/Event/View/EventAdd&Edit/EventFormFields.swift
@@ -13,6 +13,7 @@ public struct EventFormFields: View {
     @Binding var content: String
     @Binding var people: String
     @Binding var place: EventWherePlace?
+    @FocusState.Binding var isFocused: Bool
 
     @ObservedObject var categorySelectViewModel: CategorySelectViewModel
     @Binding var isCategorySelectButtonTapped: Bool
@@ -24,7 +25,8 @@ public struct EventFormFields: View {
             CustomTextFieldWithLabel(
                 label: "쿠키 제목",
                 text: $title,
-                placeholder: "쿠키의 제목을 입력해주세요."
+                placeholder: "쿠키의 제목을 입력해주세요.",
+                isFocused: $isFocused
             )
             
             CustomPlaceFieldWithLabel(
@@ -32,19 +34,23 @@ public struct EventFormFields: View {
                 placeText: $placeText,
                 placeholder: "장소를 직접 입력하거나 지도에서 선택해주세요.",
                 locationSearchService: locationSearchService,
-                place: $place
+                place: $place,
+                isFocused: $isFocused
+
             )
             
             CustomTextFieldWithLabel(
                 label: "내용",
                 text: $content,
-                placeholder: "어떤 활동을 하셨나요?"
+                placeholder: "어떤 활동을 하셨나요?",
+                isFocused: $isFocused
             )
             
             CustomTextFieldWithLabel(
                 label: "함께한 사람",
                 text: $people,
-                placeholder: "함께한 사람들을 입력해주세요."
+                placeholder: "함께한 사람들을 입력해주세요.",
+                isFocused: $isFocused
             )
             
             CategorySelectorView(

--- a/Cookiee/Cookiee/UIComponent/CustomPlaceFieldWithLabel.swift
+++ b/Cookiee/Cookiee/UIComponent/CustomPlaceFieldWithLabel.swift
@@ -14,7 +14,7 @@ struct CustomPlaceFieldWithLabel: View {
     @ObservedObject var locationSearchService: EventMapLocationSearchViewModel
     @Binding var place: EventWherePlace?
     
-    @FocusState private var isFocused: Bool
+    @FocusState.Binding var isFocused: Bool
     
     var body: some View {
         VStack(alignment: .leading) {

--- a/Cookiee/Cookiee/UIComponent/CustomTextField.swift
+++ b/Cookiee/Cookiee/UIComponent/CustomTextField.swift
@@ -29,3 +29,27 @@ struct CustomTextField: View {
         )
     }
 }
+
+struct CustomTextFieldWithMulLine: View {
+    @Binding var target: String
+    var placeholder: String
+    
+    var body: some View {
+        TextField("\(target)", text: $target, axis: .vertical)
+            .placeholder(when: target.isEmpty) {
+                Text("\(placeholder)")
+                    .foregroundStyle(Color.Brown05)
+                    .font(.Body0_M)
+        }
+        .multilineTextAlignment(.leading)
+        .lineLimit(3...5)
+        .padding(10)
+        .font(.Body0_M)
+        .background(Color.white)
+        .cornerRadius(5)
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(Color.Brown02, lineWidth: 1)
+        )
+    }
+}

--- a/Cookiee/Cookiee/UIComponent/CustomTextField.swift
+++ b/Cookiee/Cookiee/UIComponent/CustomTextField.swift
@@ -42,7 +42,7 @@ struct CustomTextFieldWithMulLine: View {
                     .font(.Body0_M)
         }
         .multilineTextAlignment(.leading)
-        .lineLimit(3...5)
+        .lineLimit(3)
         .padding(10)
         .font(.Body0_M)
         .background(Color.white)

--- a/Cookiee/Cookiee/UIComponent/CustomTextFieldWithLabel.swift
+++ b/Cookiee/Cookiee/UIComponent/CustomTextFieldWithLabel.swift
@@ -12,7 +12,7 @@ struct CustomTextFieldWithLabel: View {
     @Binding var text: String
     var placeholder: String
     
-    @FocusState private var isFocused: Bool
+    @FocusState.Binding var isFocused: Bool
     
     var body: some View {
         VStack(alignment: .leading) {

--- a/Cookiee/Cookiee/UIComponent/CustomTextFieldWithLabel.swift
+++ b/Cookiee/Cookiee/UIComponent/CustomTextFieldWithLabel.swift
@@ -21,8 +21,13 @@ struct CustomTextFieldWithLabel: View {
                 .foregroundStyle(Color.Brown02)
                 .frame(width: 75, alignment: .leading)
             
-            CustomTextField(target: $text, placeholder: placeholder)
-                .focused($isFocused)
+            if label == "내용" {
+                CustomTextFieldWithMulLine(target: $text, placeholder: placeholder)
+                    .focused($isFocused)
+            } else {
+                CustomTextField(target: $text, placeholder: placeholder)
+                    .focused($isFocused)
+            }
         }
         .padding(.bottom, 25)
     }


### PR DESCRIPTION
## Close Issue
closed #157 

## 작업 내용
- 이벤트 추가수정 내용 필드 3줄로 변경
- 다른 화면 탭 시 키보드 내리기

## 스크린샷

https://github.com/user-attachments/assets/5a1da000-d74c-45a0-a35a-88ff060bdaf7

