### PR TITLE
[FEAT] #163 - 프로필 사진 정방형으로 편집 가능

### DIFF
--- a/Cookiee/Cookiee/UIComponent/ImagePicker.swift
+++ b/Cookiee/Cookiee/UIComponent/ImagePicker.swift
@@ -19,12 +19,11 @@ struct ImagePicker: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> some UIViewController {
         let picker = UIImagePickerController()
         picker.delegate = context.coordinator
+        picker.allowsEditing = true
         return picker
     }
     
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
-        
-    }
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
 }
 
 extension ImagePicker {
@@ -36,9 +35,13 @@ extension ImagePicker {
         }
         
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-            guard let image = info[.originalImage] as? UIImage else { return }
-            parent.image = image
+            if let editedImage = info[.editedImage] as? UIImage {
+                parent.image = editedImage
+            } else if let originalImage = info[.originalImage] as? UIImage {
+                parent.image = originalImage
+            }
             parent.mode.wrappedValue.dismiss()
         }
     }
 }
+


### PR DESCRIPTION
## Close Issue
closed #163 

## 작업 내용
- 프로필 사진 정방형으로 편집 가능

## 스크린샷
<img width="413" alt="image" src="https://github.com/user-attachments/assets/abbc8129-0af6-48ca-a018-a03ffd354fcf" />
